### PR TITLE
Update Decks Website

### DIFF
--- a/app.py
+++ b/app.py
@@ -234,14 +234,87 @@ def commands():
         log.exception('Unhandled exception in commands() render_template')
         return 'abc'
 
-
 @app.route('/decks/')
 def decks():
     session = DBManager.create_session()
-    decks = session.query(Deck).order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    top_decks = []
+    for deck in session.query(Deck).order_by(Deck.last_used.desc(), Deck.first_used.desc())[:25]:
+        top_decks.append(deck)
     session.close()
     return render_template('decks.html',
-            decks=decks)
+            top_decks=top_decks)
+
+@app.route('/decks/druid/')
+def decks_druid():
+    session = DBManager.create_session()
+    decks_druid = session.query(Deck).filter(Deck.deck_class=='druid').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_druid.html',
+            decks_druid=decks_druid)
+
+@app.route('/decks/hunter/')
+def decks_hunter():
+    session = DBManager.create_session()
+    decks_hunter = session.query(Deck).filter(Deck.deck_class=='hunter').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_hunter.html',
+            decks_hunter=decks_hunter)
+
+@app.route('/decks/mage/')
+def decks_mage():
+    session = DBManager.create_session()
+    decks_mage = session.query(Deck).filter(Deck.deck_class=='mage').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_mage.html',
+            decks_mage=decks_mage)
+
+@app.route('/decks/paladin/')
+def decks_paladin():
+    session = DBManager.create_session()
+    decks_paladin = session.query(Deck).filter(Deck.deck_class=='paladin').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_paladin.html',
+            decks_paladin=decks_paladin)
+
+@app.route('/decks/priest/')
+def decks_priest():
+    session = DBManager.create_session()
+    decks_priest = session.query(Deck).filter(Deck.deck_class=='priest').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_priest.html',
+            decks_priest=decks_priest)
+
+@app.route('/decks/rogue/')
+def decks_rogue():
+    session = DBManager.create_session()
+    decks_rogue = session.query(Deck).filter(Deck.deck_class=='rogue').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_rogue.html',
+            decks_rogue=decks_rogue)
+
+@app.route('/decks/shaman/')
+def decks_shaman():
+    session = DBManager.create_session()
+    decks_shaman = session.query(Deck).filter(Deck.deck_class=='shaman').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_shaman.html',
+            decks_shaman=decks_shaman)
+
+@app.route('/decks/warlock/')
+def decks_warlock():
+    session = DBManager.create_session()
+    decks_warlock = session.query(Deck).filter(Deck.deck_class=='warlock').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_warlock.html',
+            decks_warlock=decks_warlock)
+
+@app.route('/decks/warrior/')
+def decks_warrior():
+    session = DBManager.create_session()
+    decks_warrior = session.query(Deck).filter(Deck.deck_class=='warrior').order_by(Deck.last_used.desc(), Deck.first_used.desc()).all()
+    session.close()
+    return render_template('decks_warrior.html',
+            decks_warrior=decks_warrior)
 
 
 @app.route('/user/<username>')
@@ -430,6 +503,7 @@ default_variables = {
             },
         'site': {
             'domain': config['web']['domain'],
+            'decks': config['web']['decks'],
             },
         'streamer': {
             'name': config['web']['streamer_name'],

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -85,7 +85,7 @@ div.pui.class.undefined { background: url('/static/images/class_undefined_32.png
     color: #922;
 }
 
-.user.l750,
+.user.l750
 {
     color: #11f;
 }

--- a/templates/decks_druid.html
+++ b/templates/decks_druid.html
@@ -1,11 +1,11 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Druid{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
-    <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
+<h2>Decks - Druid</h2>
+<div id="decks_druid">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
+    <a class="item druid active"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
@@ -16,8 +16,8 @@
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
-    <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
+    <a class="item druid active"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_druid %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_hunter.html
+++ b/templates/decks_hunter.html
@@ -1,12 +1,12 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Hunter{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Hunter</h2>
+<div id="decks_hunter">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
-    <a class="item hunter" href="/decks/hunter/">Hunter</a>
+    <a class="item hunter active" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
@@ -16,9 +16,9 @@
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
-    <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
+    <a class="item hunter active" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_hunter %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_mage.html
+++ b/templates/decks_mage.html
@@ -1,13 +1,13 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Mage{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Mage</h2>
+<div id="decks_mage">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
-    <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
+    <a class="item mage active" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
@@ -16,10 +16,10 @@
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
-    <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
+    <a class="item mage active" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_mage %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_paladin.html
+++ b/templates/decks_paladin.html
@@ -1,14 +1,14 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Paladin{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Paladin</h2>
+<div id="decks_paladin">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
-    <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
+    <a class="item paladin active" data-tab="paladin" href="/decks/paladin/">Paladin</a>
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
@@ -16,11 +16,11 @@
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
-    <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
+    <a class="item paladin active" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_paladin %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_priest.html
+++ b/templates/decks_priest.html
@@ -1,27 +1,27 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Priest{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Priest</h2>
+<div id="decks_priest">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
-    <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
+    <a class="item priest active" data-tab="priest" href="/decks/priest/">Priest</a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/">Warlock</a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
-    <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
+    <a class="item priest active" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_priest %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_rogue.html
+++ b/templates/decks_rogue.html
@@ -1,28 +1,28 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Rogue{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Rogue</h2>
+<div id="decks_rogue">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
-    <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
+    <a class="item rogue active" data-tab="rogue" href="/decks/rogue/">Rogue</a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/">Warlock</a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
-    <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
+    <a class="item rogue active" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/"><img src="/static/images/class_warrior_32.png" alt="Warrior"></a>
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_rogue %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_shaman.html
+++ b/templates/decks_shaman.html
@@ -1,29 +1,29 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Shaman{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Shaman</h2>
+<div id="decks_shaman">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/">Paladin</a>
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
-    <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
+    <a class="item shaman active" data-tab="shaman" href="/decks/shaman/">Shaman</a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/">Warlock</a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
     <a class="item paladin" data-tab="paladin" href="/decks/paladin/"><img src="/static/images/class_paladin_32.png" alt="Paladin"></a>
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
-    <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
+    <a class="item shaman active" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/"><img src="/static/images/class_warrior_32.png" alt="Warrior"></a>
 </div>{% endif %}
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_shaman %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_warlock.html
+++ b/templates/decks_warlock.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Warlock{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Warlock</h2>
+<div id="decks_warlock">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
@@ -12,11 +12,11 @@
     <a class="item priest" data-tab="priest" href="/decks/priest/">Priest</a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
-    <a class="item warlock" data-tab="warlock" href="/decks/warlock/">Warlock</a>
+    <a class="item warlock active" data-tab="warlock" href="/decks/warlock/">Warlock</a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
@@ -24,7 +24,7 @@
     <a class="item priest" data-tab="priest" href="/decks/priest/"><img src="/static/images/class_priest_32.png" alt="Priest"></a>
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
-    <a class="item warlock" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
+    <a class="item warlock active" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
     <a class="item warrior" data-tab="warrior" href="/decks/warrior/"><img src="/static/images/class_warrior_32.png" alt="Warrior"></a>
 </div>{% endif %}
 <div class="ui bottom attached tab segment active" data-tab="custom">
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_warlock %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>

--- a/templates/decks_warrior.html
+++ b/templates/decks_warrior.html
@@ -1,10 +1,10 @@
 {% extends "layout.html" %}
 {% set active_page = 'decks' %}
-{% block title %}Decks - Top 25{% endblock %}
+{% block title %}Decks - Warrior{% endblock %}
 {% block body %}
-<h2>Decks - Top 25</h2>
-<div id="decks_top">{% if site.decks == '0' %}
-<div class="ui top attached tabular menu"><a class="item all active" data-tab="all" href="/decks/">All</a>
+<h2>Decks - Warrior</h2>
+<div id="decks_warrior">{% if site.decks == '0' %}
+<div class="ui top attached tabular menu"><a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/">Druid</a>
     <a class="item hunter" href="/decks/hunter/">Hunter</a>
     <a class="item mage" data-tab="mage" href="decks/mage">Mage</a>
@@ -13,10 +13,10 @@
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/">Rogue</a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/">Shaman</a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/">Warlock</a>
-    <a class="item warrior" data-tab="warrior" href="/decks/warrior/">Warrior</a>
+    <a class="item warrior active" data-tab="warrior" href="/decks/warrior/">Warrior</a>
 </div>{% elif site.decks == '1' %}
 <div class="ui top attached tabular menu">
-    <a class="item all active" data-tab="all" href="/decks/">All</a>
+    <a class="item all" data-tab="all" href="/decks/">All</a>
     <a class="item druid"  data-tab="druid" href="/decks/druid/"><img src="/static/images/class_druid_32.png" alt="Druid"></a>
     <a class="item hunter" href="/decks/hunter/"><img src="/static/images/class_hunter_32.png" alt="Hunter"></a>
     <a class="item mage" data-tab="mage" href="decks/mage"><img src="/static/images/class_mage_32.png" alt="Mage"></a>
@@ -25,7 +25,7 @@
     <a class="item rogue" data-tab="rogue" href="/decks/rogue/"><img src="/static/images/class_rogue_32.png" alt="Rogue"></a>
     <a class="item shaman" data-tab="shaman" href="/decks/shaman/"><img src="/static/images/class_shaman_32.png" alt="Shaman"></a>
     <a class="item warlock" data-tab="warlock" href="/decks/warlock/"><img src="/static/images/class_warlock_32.png" alt="Warlock"></a>
-    <a class="item warrior" data-tab="warrior" href="/decks/warrior/"><img src="/static/images/class_warrior_32.png" alt="Warrior"></a>
+    <a class="item warrior active" data-tab="warrior" href="/decks/warrior/"><img src="/static/images/class_warrior_32.png" alt="Warrior"></a>
 </div>{% endif %}
 <div class="ui bottom attached tab segment active" data-tab="custom">
     <table class="ui very basic table">
@@ -39,7 +39,7 @@
             </tr>
         </thead>
         <tbody>
-{% for deck in top_decks %}
+{% for deck in decks_warrior %}
 {% include 'list/deck.html' %}
 {% endfor %}
         </tbody>


### PR DESCRIPTION
updated Decks with filters for every class
Added new templates to open decks filtered for every class in a new website.
(not with javascripts in background, but for now it should work with every website in a new link)

Set the limit to 25 for the /decks/ page,
who needs older Decks should watch the other pages.

EXAMPLE http://imgur.com/6CnwsBg

You can change from text to images if you want.

You just need to change the config.ini


[web]
; sort Decks, Images = 1 , Text = 0 [EXAMPLE](http://imgur.com/6CnwsBg)
decks = 0


and fixed a css error, there was one comma to much :facepunch: 