### PR TITLE
Add initial travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# Travis CI checks for tyggbot
+
+language: python
+
+python:
+  - 3.4
+
+install:
+  - pip install -r pip-requirements.txt --use-mirrors
+
+script:
+  - ./tests/tests.py


### PR DESCRIPTION
You're welcome.

Although I don't know wtf your binding is for tests tho. Imports tyggbot from tests even though we run via `./main.py` (see below).

But this is the initial commit.

Just login to travis-ci.org with your github account and enable your repo for builds.

```bash
Using worker: worker-linux-docker-cbc7a132.prod.travis-ci.org:travis-linux-6

system_info

Build system information

Build language: python

Build group: stable

Build dist: precise

Build image provisioning date and time

Thu Feb  5 15:09:33 UTC 2015

Operating System Details

Distributor ID: Ubuntu

Description:    Ubuntu 12.04.5 LTS

Release:        12.04

Codename:       precise

Linux Version

3.13.0-29-generic

Cookbooks Version

a68419e https://github.com/travis-ci/travis-cookbooks/tree/a68419e

GCC version

gcc (Ubuntu/Linaro 4.6.3-1ubuntu5) 4.6.3

Copyright (C) 2011 Free Software Foundation, Inc.

This is free software; see the source for copying conditions.  There is NO

warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

LLVM version

clang version 3.4 (tags/RELEASE_34/final)

Target: x86_64-unknown-linux-gnu

Thread model: posix

Pre-installed Ruby versions

ruby-1.9.3-p551

Pre-installed Node.js versions

v0.10.36

Pre-installed Go versions

1.4.1

Redis version

redis-server 2.8.19

riak version

2.0.2

MongoDB version

MongoDB 2.4.12

CouchDB version

couchdb 1.6.1

Neo4j version

1.9.4

RabbitMQ Version

3.4.3

ElasticSearch version

1.4.0

Installed Sphinx versions

2.0.10

2.1.9

2.2.6

Default Sphinx version

2.2.6

Installed Firefox version

firefox 31.0esr

PhantomJS version

1.9.8

ant -version

Apache Ant(TM) version 1.8.2 compiled on December 3 2011

mvn -version

Apache Maven 3.2.5 (12a6b3acb947671f09b81f49094c53f426d8cea1; 2014-12-14T17:29:23+00:00)

Maven home: /usr/local/maven

Java version: 1.7.0_76, vendor: Oracle Corporation

Java home: /usr/lib/jvm/java-7-oracle/jre

Default locale: en_US, platform encoding: ANSI_X3.4-1968

OS name: "linux", version: "3.13.0-29-generic", arch: "amd64", family: "unix"

git.checkout

0.40s$ git clone --depth=50 --branch=master https://github.com/cdrage/tyggbot.git cdrage/tyggbot

Cloning into 'cdrage/tyggbot'...

remote: Counting objects: 729, done.

remote: Compressing objects: 100% (410/410), done.

remote: Total 729 (delta 393), reused 594 (delta 300), pack-reused 0

Receiving objects: 100% (729/729), 342.31 KiB | 0 bytes/s, done.

Resolving deltas: 100% (393/393), done.

Checking connectivity... done.

$ cd cdrage/tyggbot

$ git checkout -qf d72d92cd0ed406c66f1e28a2853ff8da0474f61c

This job is running on container-based infrastructure, which does not allow use of 'sudo', setuid and setguid executables.

If you require sudo, add 'sudo: required' to your .travis.yml

See http://docs.travis-ci.com/user/workers/container-based-infrastructure/ for details.

0.00s$ source ~/virtualenv/python3.4/bin/activate

$ python --version

Python 3.4.2

$ pip --version

pip 6.0.7 from /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages (python 3.4)
install

64.27s$ pip install -r pip-requirements.txt --use-mirrors

You are using pip version 6.0.7, however version 7.1.2 is available.

You should consider upgrading via the 'pip install --upgrade pip' command.

DEPRECATION: --use-mirrors has been deprecated and will be removed in the future. Explicit uses of --index-url and/or --extra-index-url is suggested.

Collecting git+git://github.com/pajlada/tweepy.git (from -r pip-requirements.txt (line 8))

  Cloning git://github.com/pajlada/tweepy.git to /tmp/pip-cwk8pg7r-build

Collecting sqlalchemy (from -r pip-requirements.txt (line 2))

  Downloading SQLAlchemy-1.0.10.tar.gz (4.7MB)

    100% |################################| 4.7MB 138kB/s 

Collecting alembic (from -r pip-requirements.txt (line 5))

  Downloading alembic-0.8.4.tar.gz (950kB)

    100% |################################| 954kB 606kB/s 

Collecting irc (from -r pip-requirements.txt (line 11))

  Downloading irc-13.2-py2.py3-none-any.whl (75kB)

    100% |################################| 77kB 6.2MB/s 

Collecting wolframalpha (from -r pip-requirements.txt (line 13))

  Downloading wolframalpha-1.4-py2.py3-none-any.whl

Collecting colorama (from -r pip-requirements.txt (line 14))

  Downloading colorama-0.3.5-py2.py3-none-any.whl

Collecting pytz (from -r pip-requirements.txt (line 15))

  Downloading pytz-2015.7-py2.py3-none-any.whl (476kB)

    100% |################################| 479kB 1.3MB/s 

Collecting autobahn[twisted] (from -r pip-requirements.txt (line 16))

  Downloading autobahn-0.11.0.tar.gz (149kB)

    100% |################################| 151kB 3.5MB/s 

    package init file 'twisted/plugins/__init__.py' not found (or not a regular file)

Collecting beautifulsoup4 (from -r pip-requirements.txt (line 17))

  Downloading beautifulsoup4-4.4.1-py3-none-any.whl (81kB)

    100% |################################| 81kB 6.0MB/s 

Collecting requests (from -r pip-requirements.txt (line 18))

  Downloading requests-2.9.0-py2.py3-none-any.whl (500kB)

    100% |################################| 503kB 1.3MB/s 

Collecting regex (from -r pip-requirements.txt (line 19))

  Downloading regex-2015.11.22.tar.gz (574kB)

    100% |################################| 577kB 1.1MB/s 

Collecting pymysql (from -r pip-requirements.txt (line 22))

  Downloading PyMySQL-0.6.7-py2.py3-none-any.whl (69kB)

    100% |################################| 73kB 6.8MB/s 

Collecting flask (from -r pip-requirements.txt (line 25))

  Downloading Flask-0.10.1.tar.gz (544kB)

    100% |################################| 544kB 1.2MB/s 

Collecting flask-scrypt (from -r pip-requirements.txt (line 26))

  Downloading Flask-Scrypt-0.1.3.6.tar.gz

Collecting flask-oauthlib (from -r pip-requirements.txt (line 27))

  Downloading Flask-OAuthlib-0.9.2.tar.gz

Collecting markdown (from -r pip-requirements.txt (line 28))

  Downloading Markdown-2.6.5.tar.gz (301kB)

    100% |################################| 303kB 2.1MB/s 

Collecting apscheduler (from -r pip-requirements.txt (line 29))

  Downloading APScheduler-3.0.5-py2.py3-none-any.whl (49kB)

    100% |################################| 53kB 8.3MB/s 

Collecting google-api-python-client (from -r pip-requirements.txt (line 36))

  Downloading google_api_python_client-1.4.2-py2.py3-none-any.whl (48kB)

    100% |################################| 49kB 8.6MB/s 

Collecting isodate (from -r pip-requirements.txt (line 37))

  Downloading isodate-0.5.4.tar.gz

Collecting Pillow (from -r pip-requirements.txt (line 40))

  Downloading Pillow-3.0.0.tar.gz (9.6MB)

    100% |################################| 9.6MB 67kB/s 

Collecting requests-oauthlib>=0.4.1 (from tweepy==3.3.0->-r pip-requirements.txt (line 8))

  Downloading requests_oauthlib-0.6.0-py2.py3-none-any.whl

Collecting six>=1.7.3 (from tweepy==3.3.0->-r pip-requirements.txt (line 8))

  Downloading six-1.10.0-py2.py3-none-any.whl

Collecting Mako (from alembic->-r pip-requirements.txt (line 5))

  Downloading Mako-1.0.3.tar.gz (565kB)

    100% |################################| 565kB 747kB/s 

Collecting python-editor>=0.3 (from alembic->-r pip-requirements.txt (line 5))

  Downloading python-editor-0.5.tar.gz

Collecting jaraco.functools>=1.5 (from irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.functools-1.8.1-py2.py3-none-any.whl

Collecting jaraco.logging (from irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.logging-1.2.zip

    Installed /tmp/pip-build-6687n3bi/jaraco.logging/.eggs/setuptools_scm-1.10.1-py3.4.egg

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-0.26)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.0.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.1.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.2.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.3.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.4.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

Collecting jaraco.text (from irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.text-1.4.tar.gz

    zip_safe flag not set; analyzing archive contents...

    Installed /tmp/pip-build-6687n3bi/jaraco.text/.eggs/hgtools-6.3-py3.4.egg

Collecting jaraco.itertools (from irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.itertools-1.7-py2.py3-none-any.whl

Collecting jaraco.collections (from irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.collections-1.3.1-py2.py3-none-any.whl

Collecting txaio>=2.2.0 (from autobahn[twisted]->-r pip-requirements.txt (line 16))

  Downloading txaio-2.2.0.tar.gz

Collecting zope.interface>=3.6 (from autobahn[twisted]->-r pip-requirements.txt (line 16))

  Downloading zope.interface-4.1.3.tar.gz (141kB)

    100% |################################| 143kB 3.5MB/s 

Collecting Twisted>=12.1 (from autobahn[twisted]->-r pip-requirements.txt (line 16))

  Downloading Twisted-15.5.0.tar.bz2 (3.1MB)

    100% |################################| 3.1MB 168kB/s 

    file twisted.py (for module twisted) not found

    file twisted/application.py (for module twisted.application) not found

    file twisted/application/test.py (for module twisted.application.test) not found

    file twisted/cred.py (for module twisted.cred) not found

    file twisted/cred/test.py (for module twisted.cred.test) not found

    file twisted/internet.py (for module twisted.internet) not found

    file twisted/internet/test.py (for module twisted.internet.test) not found

    file twisted/logger.py (for module twisted.logger) not found

    file twisted/logger/test.py (for module twisted.logger.test) not found

    file twisted/names.py (for module twisted.names) not found

    file twisted/names/test.py (for module twisted.names.test) not found

    file twisted/persisted.py (for module twisted.persisted) not found

    file twisted/plugins.py (for module twisted.plugins) not found

    file twisted/positioning.py (for module twisted.positioning) not found

    file twisted/protocols.py (for module twisted.protocols) not found

    file twisted/protocols/test.py (for module twisted.protocols.test) not found

    file twisted/python.py (for module twisted.python) not found

    file twisted/python/test.py (for module twisted.python.test) not found

    file twisted/scripts.py (for module twisted.scripts) not found

    file twisted/test.py (for module twisted.test) not found

    file twisted/_threads.py (for module twisted._threads) not found

    file twisted/trial.py (for module twisted.trial) not found

    file twisted/trial/test.py (for module twisted.trial.test) not found

    file twisted/web.py (for module twisted.web) not found

    file twisted/web/_auth.py (for module twisted.web._auth) not found

    file twisted/web/test.py (for module twisted.web.test) not found

Collecting Werkzeug>=0.7 (from flask->-r pip-requirements.txt (line 25))

  Downloading Werkzeug-0.11.3-py2.py3-none-any.whl (305kB)

    100% |################################| 307kB 2.0MB/s 

Collecting Jinja2>=2.4 (from flask->-r pip-requirements.txt (line 25))

  Downloading Jinja2-2.8-py2.py3-none-any.whl (263kB)

    100% |################################| 266kB 3.2MB/s 

Collecting itsdangerous>=0.21 (from flask->-r pip-requirements.txt (line 25))

  Downloading itsdangerous-0.24.tar.gz (46kB)

    100% |################################| 49kB 5.9MB/s 

Collecting scrypt (from flask-scrypt->-r pip-requirements.txt (line 26))

  Downloading scrypt-0.7.1.tar.gz

Collecting oauthlib>=0.6.2 (from flask-oauthlib->-r pip-requirements.txt (line 27))

  Downloading oauthlib-1.0.3.tar.gz (109kB)

    100% |################################| 110kB 4.8MB/s 

Collecting tzlocal (from apscheduler->-r pip-requirements.txt (line 29))

  Downloading tzlocal-1.2.tar.gz

Collecting httplib2>=0.8 (from google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading httplib2-0.9.2.tar.gz (205kB)

    100% |################################| 208kB 2.7MB/s 

Collecting oauth2client>=1.4.6 (from google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading oauth2client-1.5.2.tar.gz (56kB)

    100% |################################| 57kB 7.5MB/s 

Collecting uritemplate>=0.6 (from google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading uritemplate-0.6.tar.gz

Collecting MarkupSafe>=0.9.2 (from Mako->alembic->-r pip-requirements.txt (line 5))

  Downloading MarkupSafe-0.23.tar.gz

Collecting tempora (from jaraco.logging->irc->-r pip-requirements.txt (line 11))

  Downloading tempora-1.3.zip

    Installed /tmp/pip-build-6687n3bi/tempora/.eggs/setuptools_scm-1.10.1-py3.4.egg

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-0.26)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.0.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.1.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.2.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.3.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.4.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

Collecting jaraco.context>=1.3 (from jaraco.text->irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.context-1.5.2.tar.gz

    Installed /tmp/pip-build-6687n3bi/jaraco.context/.eggs/setuptools_scm-1.10.1-py3.4.egg

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-0.26)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.0.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.1.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.2.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.3.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.4.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

Collecting inflect (from jaraco.itertools->irc->-r pip-requirements.txt (line 11))

  Downloading inflect-0.2.5-py2.py3-none-any.whl (58kB)

    100% |################################| 61kB 7.5MB/s 

Collecting more-itertools (from jaraco.itertools->irc->-r pip-requirements.txt (line 11))

  Downloading more-itertools-2.2.tar.gz

Collecting jaraco.classes (from jaraco.collections->irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.classes-1.2.zip

    zip_safe flag not set; analyzing archive contents...

    Installed /tmp/pip-build-6687n3bi/jaraco.classes/.eggs/hgtools-6.3-py3.4.egg

Requirement already satisfied (use --upgrade to upgrade): setuptools in /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages (from zope.interface>=3.6->autobahn[twisted]->-r pip-requirements.txt (line 16))

Collecting pyasn1>=0.1.7 (from oauth2client>=1.4.6->google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading pyasn1-0.1.9-py2.py3-none-any.whl

Collecting pyasn1-modules>=0.0.5 (from oauth2client>=1.4.6->google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading pyasn1_modules-0.0.8-py2.py3-none-any.whl

Collecting rsa>=3.1.4 (from oauth2client>=1.4.6->google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading rsa-3.2.3-py2.py3-none-any.whl (44kB)

    100% |################################| 45kB 465kB/s 

Collecting simplejson>=2.5.0 (from uritemplate>=0.6->google-api-python-client->-r pip-requirements.txt (line 36))

  Downloading simplejson-3.8.1.tar.gz (76kB)

    100% |################################| 77kB 6.1MB/s 

Collecting jaraco.apt (from jaraco.context>=1.3->jaraco.text->irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.apt-1.0.zip

    zip_safe flag not set; analyzing archive contents...

    Installed /tmp/pip-build-6687n3bi/jaraco.apt/.eggs/hgtools-6.3-py3.4.egg

Collecting yg.lockfile (from jaraco.context>=1.3->jaraco.text->irc->-r pip-requirements.txt (line 11))

  Downloading yg.lockfile-2.1.tar.gz

    Installed /tmp/pip-build-6687n3bi/yg.lockfile/.eggs/setuptools_scm-1.10.1-py3.4.egg

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-0.26)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.0.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.1.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.2.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.3.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.4.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

Collecting zc.lockfile (from yg.lockfile->jaraco.context>=1.3->jaraco.text->irc->-r pip-requirements.txt (line 11))

  Downloading zc.lockfile-1.1.0.zip

Collecting jaraco.timing (from yg.lockfile->jaraco.context>=1.3->jaraco.text->irc->-r pip-requirements.txt (line 11))

  Downloading jaraco.timing-1.1.5.tar.gz

    Installed /tmp/pip-build-6687n3bi/jaraco.timing/.eggs/setuptools_scm-1.10.1-py3.4.egg

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-0.26)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.0.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.1.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.2.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.3.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

    /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/pkg_resources/__init__.py:2510: PEP440Warning: 'setuptools (scm-1.4.0)' is being parsed as a legacy, non PEP 440, version. You may find odd behavior and sort order. In particular it will be sorted as less than 0.0. It is recommend to migrate to PEP 440 compatible versions.

      PEP440Warning,

Installing collected packages: jaraco.timing, zc.lockfile, yg.lockfile, jaraco.apt, simplejson, rsa, pyasn1-modules, pyasn1, jaraco.classes, more-itertools, inflect, jaraco.context, tempora, MarkupSafe, uritemplate, oauth2client, httplib2, tzlocal, oauthlib, scrypt, itsdangerous, Jinja2, Werkzeug, Twisted, zope.interface, txaio, jaraco.collections, jaraco.itertools, jaraco.text, jaraco.logging, jaraco.functools, python-editor, Mako, tweepy, six, requests-oauthlib, Pillow, isodate, google-api-python-client, apscheduler, markdown, flask-oauthlib, flask-scrypt, flask, pymysql, regex, requests, beautifulsoup4, autobahn, pytz, colorama, wolframalpha, irc, alembic, sqlalchemy

  Running setup.py install for jaraco.timing

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco.timing-1.1.5-py3.4-nspkg.pth

  Running setup.py install for zc.lockfile

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/zc/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/zc.lockfile-1.1.0-py3.4-nspkg.pth

  Running setup.py install for yg.lockfile

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/yg/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/yg.lockfile-2.1-py3.4-nspkg.pth

  Running setup.py install for jaraco.apt

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco.apt-1.0-py3.4-nspkg.pth

  Running setup.py install for simplejson

    building 'simplejson._speedups' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c simplejson/_speedups.c -o build/temp.linux-x86_64-3.4/simplejson/_speedups.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/simplejson/_speedups.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/simplejson/_speedups.cpython-34m.so

  Running setup.py install for jaraco.classes

    /home/travis/virtualenv/python3.4.2/lib/python3.4/importlib/_bootstrap.py:321: UserWarning: Module jaraco was already imported from None, but /tmp/pip-build-6687n3bi/jaraco.classes is being added to sys.path

      return f(*args, **kwds)

  Running setup.py install for more-itertools

    Fixing build/lib/more_itertools/__init__.py build/lib/more_itertools/more.py build/lib/more_itertools/recipes.py build/lib/more_itertools/tests/__init__.py build/lib/more_itertools/tests/test_more.py build/lib/more_itertools/tests/test_recipes.py

    Fixing build/lib/more_itertools/__init__.py build/lib/more_itertools/more.py build/lib/more_itertools/recipes.py build/lib/more_itertools/tests/__init__.py build/lib/more_itertools/tests/test_more.py build/lib/more_itertools/tests/test_recipes.py

  Running setup.py install for jaraco.context

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco.context-1.5.2-py3.4-nspkg.pth

  Running setup.py install for tempora

    Installing calc-prorate script to /home/travis/virtualenv/python3.4.2/bin

  Running setup.py install for MarkupSafe

    building 'markupsafe._speedups' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c markupsafe/_speedups.c -o build/temp.linux-x86_64-3.4/markupsafe/_speedups.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/markupsafe/_speedups.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/markupsafe/_speedups.cpython-34m.so

  Running setup.py install for uritemplate

  Running setup.py install for oauth2client

  Running setup.py install for httplib2

  Running setup.py install for tzlocal

  Running setup.py install for oauthlib

  Running setup.py install for scrypt

    building '_scrypt' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c src/scrypt.c -o build/temp.linux-x86_64-3.4/src/scrypt.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/crypto/crypto_aesctr.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/crypto_aesctr.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/crypto/crypto_scrypt-nosse.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/crypto_scrypt-nosse.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/crypto/sha256.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/sha256.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/scryptenc/scryptenc.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/scryptenc/scryptenc.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/scryptenc/scryptenc_cpuperf.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/scryptenc/scryptenc_cpuperf.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/util/memlimit.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/util/memlimit.o -O2

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_CONFIG_H -DHAVE_CLOCK_GETTIME=1 -DHAVE_LIBRT=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_STRUCT_SYSINFO=1 -DHAVE_STRUCT_SYSINFO_MEM_UNIT=1 -DHAVE_STRUCT_SYSINFO_TOTALRAM=1 -DHAVE_SYSINFO=1 -DHAVE_SYS_SYSINFO_H=1 -D_FILE_OFFSET_BITS=64 -Iscrypt-1.1.6 -Iscrypt-1.1.6/lib -Iscrypt-1.1.6/lib/scryptenc -Iscrypt-1.1.6/lib/crypto -Iscrypt-1.1.6/lib/util -I/opt/python/3.4.2/include/python3.4m -c scrypt-1.1.6/lib/util/warn.c -o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/util/warn.o -O2

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/src/scrypt.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/crypto_aesctr.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/crypto_scrypt-nosse.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/crypto/sha256.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/scryptenc/scryptenc.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/scryptenc/scryptenc_cpuperf.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/util/memlimit.o build/temp.linux-x86_64-3.4/scrypt-1.1.6/lib/util/warn.o -L/opt/python/3.4.2/lib -lcrypto -lrt -lpython3.4m -o build/lib.linux-x86_64-3.4/_scrypt.cpython-34m.so

  Running setup.py install for itsdangerous

  Running setup.py install for Twisted

    file twisted.py (for module twisted) not found

    file twisted/application.py (for module twisted.application) not found

    file twisted/application/test.py (for module twisted.application.test) not found

    file twisted/cred.py (for module twisted.cred) not found

    file twisted/cred/test.py (for module twisted.cred.test) not found

    file twisted/internet.py (for module twisted.internet) not found

    file twisted/internet/test.py (for module twisted.internet.test) not found

    file twisted/logger.py (for module twisted.logger) not found

    file twisted/logger/test.py (for module twisted.logger.test) not found

    file twisted/names.py (for module twisted.names) not found

    file twisted/names/test.py (for module twisted.names.test) not found

    file twisted/persisted.py (for module twisted.persisted) not found

    file twisted/plugins.py (for module twisted.plugins) not found

    file twisted/positioning.py (for module twisted.positioning) not found

    file twisted/protocols.py (for module twisted.protocols) not found

    file twisted/protocols/test.py (for module twisted.protocols.test) not found

    file twisted/python.py (for module twisted.python) not found

    file twisted/python/test.py (for module twisted.python.test) not found

    file twisted/scripts.py (for module twisted.scripts) not found

    file twisted/test.py (for module twisted.test) not found

    file twisted/_threads.py (for module twisted._threads) not found

    file twisted/trial.py (for module twisted.trial) not found

    file twisted/trial/test.py (for module twisted.trial.test) not found

    file twisted/web.py (for module twisted.web) not found

    file twisted/web/_auth.py (for module twisted.web._auth) not found

    file twisted/web/test.py (for module twisted.web.test) not found

    file twisted.py (for module twisted) not found

    file twisted/application.py (for module twisted.application) not found

    file twisted/application/test.py (for module twisted.application.test) not found

    file twisted/cred.py (for module twisted.cred) not found

    file twisted/cred/test.py (for module twisted.cred.test) not found

    file twisted/internet.py (for module twisted.internet) not found

    file twisted/internet/test.py (for module twisted.internet.test) not found

    file twisted/logger.py (for module twisted.logger) not found

    file twisted/logger/test.py (for module twisted.logger.test) not found

    file twisted/names.py (for module twisted.names) not found

    file twisted/names/test.py (for module twisted.names.test) not found

    file twisted/persisted.py (for module twisted.persisted) not found

    file twisted/plugins.py (for module twisted.plugins) not found

    file twisted/positioning.py (for module twisted.positioning) not found

    file twisted/protocols.py (for module twisted.protocols) not found

    file twisted/protocols/test.py (for module twisted.protocols.test) not found

    file twisted/python.py (for module twisted.python) not found

    file twisted/python/test.py (for module twisted.python.test) not found

    file twisted/scripts.py (for module twisted.scripts) not found

    file twisted/test.py (for module twisted.test) not found

    file twisted/_threads.py (for module twisted._threads) not found

    file twisted/trial.py (for module twisted.trial) not found

    file twisted/trial/test.py (for module twisted.trial.test) not found

    file twisted/web.py (for module twisted.web) not found

    file twisted/web/_auth.py (for module twisted.web._auth) not found

    file twisted/web/test.py (for module twisted.web.test) not found

    changing mode of build/scripts-3.4/trial from 664 to 775

    changing mode of build/scripts-3.4/twistd from 664 to 775

    file twisted.py (for module twisted) not found

    file twisted/application.py (for module twisted.application) not found

    file twisted/application/test.py (for module twisted.application.test) not found

    file twisted/cred.py (for module twisted.cred) not found

    file twisted/cred/test.py (for module twisted.cred.test) not found

    file twisted/internet.py (for module twisted.internet) not found

    file twisted/internet/test.py (for module twisted.internet.test) not found

    file twisted/logger.py (for module twisted.logger) not found

    file twisted/logger/test.py (for module twisted.logger.test) not found

    file twisted/names.py (for module twisted.names) not found

    file twisted/names/test.py (for module twisted.names.test) not found

    file twisted/persisted.py (for module twisted.persisted) not found

    file twisted/plugins.py (for module twisted.plugins) not found

    file twisted/positioning.py (for module twisted.positioning) not found

    file twisted/protocols.py (for module twisted.protocols) not found

    file twisted/protocols/test.py (for module twisted.protocols.test) not found

    file twisted/python.py (for module twisted.python) not found

    file twisted/python/test.py (for module twisted.python.test) not found

    file twisted/scripts.py (for module twisted.scripts) not found

    file twisted/test.py (for module twisted.test) not found

    file twisted/_threads.py (for module twisted._threads) not found

    file twisted/trial.py (for module twisted.trial) not found

    file twisted/trial/test.py (for module twisted.trial.test) not found

    file twisted/web.py (for module twisted.web) not found

    file twisted/web/_auth.py (for module twisted.web._auth) not found

    file twisted/web/test.py (for module twisted.web.test) not found

    changing mode of /home/travis/virtualenv/python3.4.2/bin/trial to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/twistd to 775

    file twisted.py (for module twisted) not found

    file twisted/application.py (for module twisted.application) not found

    file twisted/application/test.py (for module twisted.application.test) not found

    file twisted/cred.py (for module twisted.cred) not found

    file twisted/cred/test.py (for module twisted.cred.test) not found

    file twisted/internet.py (for module twisted.internet) not found

    file twisted/internet/test.py (for module twisted.internet.test) not found

    file twisted/logger.py (for module twisted.logger) not found

    file twisted/logger/test.py (for module twisted.logger.test) not found

    file twisted/names.py (for module twisted.names) not found

    file twisted/names/test.py (for module twisted.names.test) not found

    file twisted/persisted.py (for module twisted.persisted) not found

    file twisted/plugins.py (for module twisted.plugins) not found

    file twisted/positioning.py (for module twisted.positioning) not found

    file twisted/protocols.py (for module twisted.protocols) not found

    file twisted/protocols/test.py (for module twisted.protocols.test) not found

    file twisted/python.py (for module twisted.python) not found

    file twisted/python/test.py (for module twisted.python.test) not found

    file twisted/scripts.py (for module twisted.scripts) not found

    file twisted/test.py (for module twisted.test) not found

    file twisted/_threads.py (for module twisted._threads) not found

    file twisted/trial.py (for module twisted.trial) not found

    file twisted/trial/test.py (for module twisted.trial.test) not found

    file twisted/web.py (for module twisted.web) not found

    file twisted/web/_auth.py (for module twisted.web._auth) not found

    file twisted/web/test.py (for module twisted.web.test) not found

  Running setup.py install for zope.interface

    building 'zope.interface._zope_interface_coptimizations' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c src/zope/interface/_zope_interface_coptimizations.c -o build/temp.linux-x86_64-3.4/src/zope/interface/_zope_interface_coptimizations.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/src/zope/interface/_zope_interface_coptimizations.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/zope/interface/_zope_interface_coptimizations.cpython-34m.so

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/zope/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/zope.interface-4.1.3-py3.4-nspkg.pth

  Running setup.py install for txaio

  Running setup.py install for jaraco.text

  Running setup.py install for jaraco.logging

    Skipping installation of /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco/__init__.py (namespace package)

    Installing /home/travis/virtualenv/python3.4.2/lib/python3.4/site-packages/jaraco.logging-1.2-py3.4-nspkg.pth

  Running setup.py install for python-editor

  Running setup.py install for Mako

    Installing mako-render script to /home/travis/virtualenv/python3.4.2/bin

  Running setup.py install for tweepy

  Running setup.py install for Pillow

    building 'PIL._imaging' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c _imaging.c -o build/temp.linux-x86_64-3.4/_imaging.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c outline.c -o build/temp.linux-x86_64-3.4/outline.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Bands.c -o build/temp.linux-x86_64-3.4/libImaging/Bands.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/ConvertYCbCr.c -o build/temp.linux-x86_64-3.4/libImaging/ConvertYCbCr.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Copy.c -o build/temp.linux-x86_64-3.4/libImaging/Copy.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c path.c -o build/temp.linux-x86_64-3.4/path.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/BitDecode.c -o build/temp.linux-x86_64-3.4/libImaging/BitDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Crc32.c -o build/temp.linux-x86_64-3.4/libImaging/Crc32.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Blend.c -o build/temp.linux-x86_64-3.4/libImaging/Blend.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Crop.c -o build/temp.linux-x86_64-3.4/libImaging/Crop.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Access.c -o build/temp.linux-x86_64-3.4/libImaging/Access.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Chops.c -o build/temp.linux-x86_64-3.4/libImaging/Chops.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Dib.c -o build/temp.linux-x86_64-3.4/libImaging/Dib.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Draw.c -o build/temp.linux-x86_64-3.4/libImaging/Draw.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Convert.c -o build/temp.linux-x86_64-3.4/libImaging/Convert.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/AlphaComposite.c -o build/temp.linux-x86_64-3.4/libImaging/AlphaComposite.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c decode.c -o build/temp.linux-x86_64-3.4/decode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Resample.c -o build/temp.linux-x86_64-3.4/libImaging/Resample.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c encode.c -o build/temp.linux-x86_64-3.4/encode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Effects.c -o build/temp.linux-x86_64-3.4/libImaging/Effects.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Filter.c -o build/temp.linux-x86_64-3.4/libImaging/Filter.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/EpsEncode.c -o build/temp.linux-x86_64-3.4/libImaging/EpsEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c map.c -o build/temp.linux-x86_64-3.4/map.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/File.c -o build/temp.linux-x86_64-3.4/libImaging/File.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/FliDecode.c -o build/temp.linux-x86_64-3.4/libImaging/FliDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/GifEncode.c -o build/temp.linux-x86_64-3.4/libImaging/GifEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c display.c -o build/temp.linux-x86_64-3.4/display.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Fill.c -o build/temp.linux-x86_64-3.4/libImaging/Fill.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Geometry.c -o build/temp.linux-x86_64-3.4/libImaging/Geometry.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/LzwDecode.c -o build/temp.linux-x86_64-3.4/libImaging/LzwDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Offset.c -o build/temp.linux-x86_64-3.4/libImaging/Offset.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Matrix.c -o build/temp.linux-x86_64-3.4/libImaging/Matrix.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Pack.c -o build/temp.linux-x86_64-3.4/libImaging/Pack.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/HexDecode.c -o build/temp.linux-x86_64-3.4/libImaging/HexDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/ModeFilter.c -o build/temp.linux-x86_64-3.4/libImaging/ModeFilter.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Histo.c -o build/temp.linux-x86_64-3.4/libImaging/Histo.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/MspDecode.c -o build/temp.linux-x86_64-3.4/libImaging/MspDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Negative.c -o build/temp.linux-x86_64-3.4/libImaging/Negative.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/PackDecode.c -o build/temp.linux-x86_64-3.4/libImaging/PackDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/GetBBox.c -o build/temp.linux-x86_64-3.4/libImaging/GetBBox.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/JpegDecode.c -o build/temp.linux-x86_64-3.4/libImaging/JpegDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Quant.c -o build/temp.linux-x86_64-3.4/libImaging/Quant.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/JpegEncode.c -o build/temp.linux-x86_64-3.4/libImaging/JpegEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Palette.c -o build/temp.linux-x86_64-3.4/libImaging/Palette.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/GifDecode.c -o build/temp.linux-x86_64-3.4/libImaging/GifDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/PcxDecode.c -o build/temp.linux-x86_64-3.4/libImaging/PcxDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/RawEncode.c -o build/temp.linux-x86_64-3.4/libImaging/RawEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/PcxEncode.c -o build/temp.linux-x86_64-3.4/libImaging/PcxEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Point.c -o build/temp.linux-x86_64-3.4/libImaging/Point.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Storage.c -o build/temp.linux-x86_64-3.4/libImaging/Storage.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/QuantOctree.c -o build/temp.linux-x86_64-3.4/libImaging/QuantOctree.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/SunRleDecode.c -o build/temp.linux-x86_64-3.4/libImaging/SunRleDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/RankFilter.c -o build/temp.linux-x86_64-3.4/libImaging/RankFilter.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Paste.c -o build/temp.linux-x86_64-3.4/libImaging/Paste.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/TgaRleDecode.c -o build/temp.linux-x86_64-3.4/libImaging/TgaRleDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/QuantHash.c -o build/temp.linux-x86_64-3.4/libImaging/QuantHash.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/RawDecode.c -o build/temp.linux-x86_64-3.4/libImaging/RawDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Unpack.c -o build/temp.linux-x86_64-3.4/libImaging/Unpack.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/UnpackYCC.c -o build/temp.linux-x86_64-3.4/libImaging/UnpackYCC.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/ZipEncode.c -o build/temp.linux-x86_64-3.4/libImaging/ZipEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/QuantHeap.c -o build/temp.linux-x86_64-3.4/libImaging/QuantHeap.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/UnsharpMask.c -o build/temp.linux-x86_64-3.4/libImaging/UnsharpMask.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/TiffDecode.c -o build/temp.linux-x86_64-3.4/libImaging/TiffDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/PcdDecode.c -o build/temp.linux-x86_64-3.4/libImaging/PcdDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/XbmDecode.c -o build/temp.linux-x86_64-3.4/libImaging/XbmDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/BoxBlur.c -o build/temp.linux-x86_64-3.4/libImaging/BoxBlur.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Incremental.c -o build/temp.linux-x86_64-3.4/libImaging/Incremental.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/XbmEncode.c -o build/temp.linux-x86_64-3.4/libImaging/XbmEncode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/ZipDecode.c -o build/temp.linux-x86_64-3.4/libImaging/ZipDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Jpeg2KDecode.c -o build/temp.linux-x86_64-3.4/libImaging/Jpeg2KDecode.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -DHAVE_LIBJPEG -DHAVE_LIBZ -DHAVE_LIBTIFF -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c libImaging/Jpeg2KEncode.c -o build/temp.linux-x86_64-3.4/libImaging/Jpeg2KEncode.o

    Building using 4 processes

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/_imaging.o build/temp.linux-x86_64-3.4/decode.o build/temp.linux-x86_64-3.4/encode.o build/temp.linux-x86_64-3.4/map.o build/temp.linux-x86_64-3.4/display.o build/temp.linux-x86_64-3.4/outline.o build/temp.linux-x86_64-3.4/path.o build/temp.linux-x86_64-3.4/libImaging/Access.o build/temp.linux-x86_64-3.4/libImaging/AlphaComposite.o build/temp.linux-x86_64-3.4/libImaging/Resample.o build/temp.linux-x86_64-3.4/libImaging/Bands.o build/temp.linux-x86_64-3.4/libImaging/BitDecode.o build/temp.linux-x86_64-3.4/libImaging/Blend.o build/temp.linux-x86_64-3.4/libImaging/Chops.o build/temp.linux-x86_64-3.4/libImaging/Convert.o build/temp.linux-x86_64-3.4/libImaging/ConvertYCbCr.o build/temp.linux-x86_64-3.4/libImaging/Copy.o build/temp.linux-x86_64-3.4/libImaging/Crc32.o build/temp.linux-x86_64-3.4/libImaging/Crop.o build/temp.linux-x86_64-3.4/libImaging/Dib.o build/temp.linux-x86_64-3.4/libImaging/Draw.o build/temp.linux-x86_64-3.4/libImaging/Effects.o build/temp.linux-x86_64-3.4/libImaging/EpsEncode.o build/temp.linux-x86_64-3.4/libImaging/File.o build/temp.linux-x86_64-3.4/libImaging/Fill.o build/temp.linux-x86_64-3.4/libImaging/Filter.o build/temp.linux-x86_64-3.4/libImaging/FliDecode.o build/temp.linux-x86_64-3.4/libImaging/Geometry.o build/temp.linux-x86_64-3.4/libImaging/GetBBox.o build/temp.linux-x86_64-3.4/libImaging/GifDecode.o build/temp.linux-x86_64-3.4/libImaging/GifEncode.o build/temp.linux-x86_64-3.4/libImaging/HexDecode.o build/temp.linux-x86_64-3.4/libImaging/Histo.o build/temp.linux-x86_64-3.4/libImaging/JpegDecode.o build/temp.linux-x86_64-3.4/libImaging/JpegEncode.o build/temp.linux-x86_64-3.4/libImaging/LzwDecode.o build/temp.linux-x86_64-3.4/libImaging/Matrix.o build/temp.linux-x86_64-3.4/libImaging/ModeFilter.o build/temp.linux-x86_64-3.4/libImaging/MspDecode.o build/temp.linux-x86_64-3.4/libImaging/Negative.o build/temp.linux-x86_64-3.4/libImaging/Offset.o build/temp.linux-x86_64-3.4/libImaging/Pack.o build/temp.linux-x86_64-3.4/libImaging/PackDecode.o build/temp.linux-x86_64-3.4/libImaging/Palette.o build/temp.linux-x86_64-3.4/libImaging/Paste.o build/temp.linux-x86_64-3.4/libImaging/Quant.o build/temp.linux-x86_64-3.4/libImaging/QuantOctree.o build/temp.linux-x86_64-3.4/libImaging/QuantHash.o build/temp.linux-x86_64-3.4/libImaging/QuantHeap.o build/temp.linux-x86_64-3.4/libImaging/PcdDecode.o build/temp.linux-x86_64-3.4/libImaging/PcxDecode.o build/temp.linux-x86_64-3.4/libImaging/PcxEncode.o build/temp.linux-x86_64-3.4/libImaging/Point.o build/temp.linux-x86_64-3.4/libImaging/RankFilter.o build/temp.linux-x86_64-3.4/libImaging/RawDecode.o build/temp.linux-x86_64-3.4/libImaging/RawEncode.o build/temp.linux-x86_64-3.4/libImaging/Storage.o build/temp.linux-x86_64-3.4/libImaging/SunRleDecode.o build/temp.linux-x86_64-3.4/libImaging/TgaRleDecode.o build/temp.linux-x86_64-3.4/libImaging/Unpack.o build/temp.linux-x86_64-3.4/libImaging/UnpackYCC.o build/temp.linux-x86_64-3.4/libImaging/UnsharpMask.o build/temp.linux-x86_64-3.4/libImaging/XbmDecode.o build/temp.linux-x86_64-3.4/libImaging/XbmEncode.o build/temp.linux-x86_64-3.4/libImaging/ZipDecode.o build/temp.linux-x86_64-3.4/libImaging/ZipEncode.o build/temp.linux-x86_64-3.4/libImaging/TiffDecode.o build/temp.linux-x86_64-3.4/libImaging/Incremental.o build/temp.linux-x86_64-3.4/libImaging/Jpeg2KDecode.o build/temp.linux-x86_64-3.4/libImaging/Jpeg2KEncode.o build/temp.linux-x86_64-3.4/libImaging/BoxBlur.o -L/home/travis/virtualenv/python3.4.2/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/opt/python/3.4.2/lib -L/usr/lib/x86_64-linux-gnu -ljpeg -lz -ltiff -lpython3.4m -o build/lib.linux-x86_64-3.4/PIL/_imaging.cpython-34m.so

    building 'PIL._imagingft' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c _imagingft.c -o build/temp.linux-x86_64-3.4/_imagingft.o

    Building using 4 processes

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/_imagingft.o -L/home/travis/virtualenv/python3.4.2/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/opt/python/3.4.2/lib -L/usr/lib/x86_64-linux-gnu -lfreetype -lpython3.4m -o build/lib.linux-x86_64-3.4/PIL/_imagingft.cpython-34m.so

    building 'PIL._imagingtk' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c _imagingtk.c -o build/temp.linux-x86_64-3.4/_imagingtk.o

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c Tk/tkImaging.c -o build/temp.linux-x86_64-3.4/Tk/tkImaging.o

    Building using 4 processes

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/_imagingtk.o build/temp.linux-x86_64-3.4/Tk/tkImaging.o -L/home/travis/virtualenv/python3.4.2/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/opt/python/3.4.2/lib -L/usr/lib/x86_64-linux-gnu -ltcl8.5 -ltk8.5 -lpython3.4m -o build/lib.linux-x86_64-3.4/PIL/_imagingtk.cpython-34m.so

    building 'PIL._imagingmath' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c _imagingmath.c -o build/temp.linux-x86_64-3.4/_imagingmath.o

    Building using 4 processes

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/_imagingmath.o -L/home/travis/virtualenv/python3.4.2/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/opt/python/3.4.2/lib -L/usr/lib/x86_64-linux-gnu -lpython3.4m -o build/lib.linux-x86_64-3.4/PIL/_imagingmath.cpython-34m.so

    building 'PIL._imagingmorph' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/usr/include/freetype2 -I/tmp/pip-build-6687n3bi/Pillow/libImaging -I/home/travis/virtualenv/python3.4.2/include -I/usr/include/tcl8.5 -I/usr/local/include -I/usr/include -I/opt/python/3.4.2/include/python3.4m -I/usr/include/x86_64-linux-gnu -c _imagingmorph.c -o build/temp.linux-x86_64-3.4/_imagingmorph.o

    Building using 4 processes

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/_imagingmorph.o -L/home/travis/virtualenv/python3.4.2/lib -L/lib64 -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -L/usr/lib -L/opt/python/3.4.2/lib -L/usr/lib/x86_64-linux-gnu -lpython3.4m -o build/lib.linux-x86_64-3.4/PIL/_imagingmorph.cpython-34m.so

    --------------------------------------------------------------------

    PIL SETUP SUMMARY

    --------------------------------------------------------------------

    version      Pillow 3.0.0

    platform     linux 3.4.2 (default, Feb  5 2015, 15:56:51)

                 [GCC 4.6.3]

    --------------------------------------------------------------------

    --- TKINTER support available

    --- JPEG support available

    *** OPENJPEG (JPEG2000) support not available

    --- ZLIB (PNG/ZIP) support available

    --- LIBTIFF support available

    --- FREETYPE2 support available

    *** LITTLECMS2 support not available

    *** WEBP support not available

    *** WEBPMUX support not available

    --------------------------------------------------------------------

    To add a missing option, make sure you have the required

    library, and set the corresponding ROOT variable in the

    setup.py script.

    To check the build, run the selftest.py script.

    changing mode of build/scripts-3.4/createfontdatachunk.py from 664 to 775

    changing mode of build/scripts-3.4/enhancer.py from 664 to 775

    changing mode of build/scripts-3.4/explode.py from 664 to 775

    changing mode of build/scripts-3.4/gifmaker.py from 664 to 775

    changing mode of build/scripts-3.4/painter.py from 664 to 775

    changing mode of build/scripts-3.4/pilconvert.py from 664 to 775

    changing mode of build/scripts-3.4/pildriver.py from 664 to 775

    changing mode of build/scripts-3.4/pilfile.py from 664 to 775

    changing mode of build/scripts-3.4/pilfont.py from 664 to 775

    changing mode of build/scripts-3.4/pilprint.py from 664 to 775

    changing mode of build/scripts-3.4/player.py from 664 to 775

    changing mode of build/scripts-3.4/thresholder.py from 664 to 775

    changing mode of build/scripts-3.4/viewer.py from 664 to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/createfontdatachunk.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/enhancer.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/explode.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/gifmaker.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/painter.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/pilconvert.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/pildriver.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/pilfile.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/pilfont.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/pilprint.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/player.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/thresholder.py to 775

    changing mode of /home/travis/virtualenv/python3.4.2/bin/viewer.py to 775

  Running setup.py install for isodate

    Fixing build/lib/isodate/__init__.py build/lib/isodate/duration.py build/lib/isodate/isodates.py build/lib/isodate/isodatetime.py build/lib/isodate/isoduration.py build/lib/isodate/isoerror.py build/lib/isodate/isostrf.py build/lib/isodate/isotime.py build/lib/isodate/isotzinfo.py build/lib/isodate/tzinfo.py build/lib/isodate/tests/__init__.py build/lib/isodate/tests/test_date.py build/lib/isodate/tests/test_datetime.py build/lib/isodate/tests/test_duration.py build/lib/isodate/tests/test_pickle.py build/lib/isodate/tests/test_strf.py build/lib/isodate/tests/test_time.py

    Fixing build/lib/isodate/__init__.py build/lib/isodate/duration.py build/lib/isodate/isodates.py build/lib/isodate/isodatetime.py build/lib/isodate/isoduration.py build/lib/isodate/isoerror.py build/lib/isodate/isostrf.py build/lib/isodate/isotime.py build/lib/isodate/isotzinfo.py build/lib/isodate/tzinfo.py build/lib/isodate/tests/__init__.py build/lib/isodate/tests/test_date.py build/lib/isodate/tests/test_datetime.py build/lib/isodate/tests/test_duration.py build/lib/isodate/tests/test_pickle.py build/lib/isodate/tests/test_strf.py build/lib/isodate/tests/test_time.py

  Running setup.py install for markdown

    changing mode of build/scripts-3.4/markdown_py from 664 to 775

    Converting docs/siteindex.txt -> build/docs/siteindex.html

    Converting docs/install.txt -> build/docs/install.html

    Converting docs/authors.txt -> build/docs/authors.html

    Converting docs/test_suite.txt -> build/docs/test_suite.html

    Converting docs/release-2.3.txt -> build/docs/release-2.3.html

    Converting docs/release-2.4.txt -> build/docs/release-2.4.html

    Converting docs/change_log.txt -> build/docs/change_log.html

    Converting docs/release-2.0.1.txt -> build/docs/release-2.0.1.html

    Converting docs/release-2.2.0.txt -> build/docs/release-2.2.0.html

    Converting docs/release-2.0.2.txt -> build/docs/release-2.0.2.html

    Converting docs/release-2.1.1.txt -> build/docs/release-2.1.1.html

    Converting docs/index.txt -> build/docs/index.html

    Converting docs/release-2.1.0.txt -> build/docs/release-2.1.0.html

    Converting docs/release-2.0.txt -> build/docs/release-2.0.html

    Converting docs/cli.txt -> build/docs/cli.html

    Converting docs/reference.txt -> build/docs/reference.html

    Converting docs/release-2.2.1.txt -> build/docs/release-2.2.1.html

    Converting docs/release-2.6.txt -> build/docs/release-2.6.html

    Converting docs/release-2.5.txt -> build/docs/release-2.5.html

    Converting docs/extensions/meta_data.txt -> build/docs/extensions/meta_data.html

    Converting docs/extensions/admonition.txt -> build/docs/extensions/admonition.html

    Converting docs/extensions/toc.txt -> build/docs/extensions/toc.html

    Converting docs/extensions/fenced_code_blocks.txt -> build/docs/extensions/fenced_code_blocks.html

    Converting docs/extensions/nl2br.txt -> build/docs/extensions/nl2br.html

    Converting docs/extensions/wikilinks.txt -> build/docs/extensions/wikilinks.html

    Converting docs/extensions/tables.txt -> build/docs/extensions/tables.html

    Converting docs/extensions/extra.txt -> build/docs/extensions/extra.html

    Converting docs/extensions/sane_lists.txt -> build/docs/extensions/sane_lists.html

    Converting docs/extensions/header_id.txt -> build/docs/extensions/header_id.html

    Converting docs/extensions/footnotes.txt -> build/docs/extensions/footnotes.html

    Converting docs/extensions/smarty.txt -> build/docs/extensions/smarty.html

    Converting docs/extensions/api.txt -> build/docs/extensions/api.html

    Converting docs/extensions/attr_list.txt -> build/docs/extensions/attr_list.html

    Converting docs/extensions/index.txt -> build/docs/extensions/index.html

    Converting docs/extensions/code_hilite.txt -> build/docs/extensions/code_hilite.html

    Converting docs/extensions/definition_lists.txt -> build/docs/extensions/definition_lists.html

    Converting docs/extensions/smart_strong.txt -> build/docs/extensions/smart_strong.html

    Converting docs/extensions/abbreviations.txt -> build/docs/extensions/abbreviations.html

    changing mode of /home/travis/virtualenv/python3.4.2/bin/markdown_py to 775

  Running setup.py install for flask-oauthlib

  Running setup.py install for flask-scrypt

  Running setup.py install for flask

  Running setup.py install for regex

    building '_regex' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c Python3/_regex.c -o build/temp.linux-x86_64-3.4/Python3/_regex.o

    Python3/_regex.c: In function ‘do_best_fuzzy_match’:

    Python3/_regex.c:16524:31: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]

    Python3/_regex.c: In function ‘do_match’:

    Python3/_regex.c:16383:9: warning: ‘status’ may be used uninitialized in this function [-Wuninitialized]

    Python3/_regex.c:16530:40: warning: ‘best_match_pos’ may be used uninitialized in this function [-Wuninitialized]

    Python3/_regex.c:16475:24: note: ‘best_match_pos’ was declared here

    Python3/_regex.c: In function ‘pattern_subx’:

    Python3/_regex.c:20622:9: warning: ‘kwargs’ may be used uninitialized in this function [-Wuninitialized]

    Python3/_regex.c:20623:9: warning: ‘args’ may be used uninitialized in this function [-Wuninitialized]

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c Python3/_regex_unicode.c -o build/temp.linux-x86_64-3.4/Python3/_regex_unicode.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/Python3/_regex.o build/temp.linux-x86_64-3.4/Python3/_regex_unicode.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/_regex.cpython-34m.so

  Running setup.py install for autobahn

    package init file 'twisted/plugins/__init__.py' not found (or not a regular file)

    Twisted found (default reactor is <class 'twisted.internet.epollreactor.EPollReactor'>)

    Twisted dropin.cache regenerated.

  Running setup.py install for alembic

    Installing alembic script to /home/travis/virtualenv/python3.4.2/bin

  Running setup.py install for sqlalchemy

    building 'sqlalchemy.cprocessors' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c lib/sqlalchemy/cextension/processors.c -o build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/processors.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/processors.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/sqlalchemy/cprocessors.cpython-34m.so

    building 'sqlalchemy.cresultproxy' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c lib/sqlalchemy/cextension/resultproxy.c -o build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/resultproxy.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/resultproxy.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/sqlalchemy/cresultproxy.cpython-34m.so

    building 'sqlalchemy.cutils' extension

    gcc -pthread -Wno-unused-result -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -fPIC -I/opt/python/3.4.2/include/python3.4m -c lib/sqlalchemy/cextension/utils.c -o build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/utils.o

    gcc -pthread -shared -L/opt/python/3.4.2/lib -Wl,-rpath=/opt/python/3.4.2/lib build/temp.linux-x86_64-3.4/lib/sqlalchemy/cextension/utils.o -L/opt/python/3.4.2/lib -lpython3.4m -o build/lib.linux-x86_64-3.4/sqlalchemy/cutils.cpython-34m.so

Successfully installed Jinja2-2.8 Mako-1.0.3 MarkupSafe-0.23 Pillow-3.0.0 Twisted-15.5.0 Werkzeug-0.11.3 alembic-0.8.4 apscheduler-3.0.5 autobahn-0.11.0 beautifulsoup4-4.4.1 colorama-0.3.5 flask-0.10.1 flask-oauthlib-0.9.2 flask-scrypt-0.1.3.6 google-api-python-client-1.4.2 httplib2-0.9.2 inflect-0.2.5 irc-13.2 isodate-0.5.4 itsdangerous-0.24 jaraco.apt-1.0 jaraco.classes-1.2 jaraco.collections-1.3.1 jaraco.context-1.5.2 jaraco.functools-1.8.1 jaraco.itertools-1.7 jaraco.logging-1.2 jaraco.text-1.4 jaraco.timing-1.1.5 markdown-2.6.5 more-itertools-2.2 oauth2client-1.5.2 oauthlib-1.0.3 pyasn1-0.1.9 pyasn1-modules-0.0.8 pymysql-0.6.7 python-editor-0.5 pytz-2015.7 regex-2015.11.22 requests-2.9.0 requests-oauthlib-0.6.0 rsa-3.2.3 scrypt-0.7.1 simplejson-3.8.1 six-1.10.0 sqlalchemy-1.0.10 tempora-1.3 tweepy-3.3.0 txaio-2.2.0 tzlocal-1.2 uritemplate-0.6 wolframalpha-1.4 yg.lockfile-2.1 zc.lockfile-1.1.0 zope.interface-4.1.3

0.08s$ ./tests/tests.py

EEEEE

======================================================================

ERROR: test_message_action_parse (__main__.ActionsTester)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "./tests/tests.py", line 60, in setUp

ImportError: cannot import name 'TyggBot'

======================================================================

ERROR: test_find_unique_urls (__main__.TestURLMethods)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "./tests/tests.py", line 39, in test_find_unique_urls

ImportError: No module named 'tyggbot.models'

======================================================================

ERROR: test_is_same_url (__main__.TestURLMethods)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "./tests/tests.py", line 31, in test_is_same_url

ImportError: No module named 'tyggbot.models'

======================================================================

ERROR: test_is_subdomain (__main__.TestURLMethods)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "./tests/tests.py", line 12, in test_is_subdomain

ImportError: No module named 'tyggbot.models'

======================================================================

ERROR: test_is_subpath (__main__.TestURLMethods)

----------------------------------------------------------------------

Traceback (most recent call last):

  File "./tests/tests.py", line 22, in test_is_subpath

ImportError: No module named 'tyggbot.models'

----------------------------------------------------------------------

Ran 5 tests in 0.006s

FAILED (errors=5)

The command "./tests/tests.py" exited with 1.

Done. Your build exited with 1.
```